### PR TITLE
Lower baud for serial on ESP8266

### DIFF
--- a/examples/GxEPD2_32_Example/GxEPD2_32_Example.ino
+++ b/examples/GxEPD2_32_Example/GxEPD2_32_Example.ino
@@ -83,7 +83,11 @@
 
 void setup()
 {
+#if defined (ESP8266)
+  Serial.begin(9600);
+#else
   Serial.begin(115200);
+#endif
   Serial.println();
   Serial.println("setup");
   display.init();


### PR DESCRIPTION
On ESP8266, if you use 115200 for Serial communication, all you see on the Arduino IDE's Serial monitor is gibberish.
With 9600 it works fine. I haven't tested intermediate bitrates.