### PR TITLE
Also draw b/w 640x384 and 3-color 400x300 bitmaps on GDEW075Z09

### DIFF
--- a/examples/GxEPD2_32_Example/GxEPD2_32_Example.ino
+++ b/examples/GxEPD2_32_Example/GxEPD2_32_Example.ino
@@ -549,7 +549,7 @@ void drawBitmaps640x384()
   {
     Bitmap640x384_1, Bitmap640x384_2
   };
-  if (display.panel() == GxEPD2::GDEW075T8)
+  if (display.panel() == GxEPD2::GDEW075T8 || display.panel() == GxEPD2::GDEW075Z09)
   {
     for (uint16_t i = 0; i < sizeof(bitmaps) / sizeof(char*); i++)
     {
@@ -725,7 +725,7 @@ void drawBitmaps3c400x300()
     {Bitmap3c400x300_2_black, Bitmap3c400x300_2_red},
     {WS_Bitmap3c400x300_black, WS_Bitmap3c400x300_red}
   };
-  if (display.panel() == GxEPD2::GDEW042Z15)
+  if (display.panel() == GxEPD2::GDEW042Z15 || display.panel() == GxEPD2::GDEW075Z09)
   {
     for (uint16_t i = 0; i < sizeof(bitmap_pairs) / sizeof(bitmap_pair); i++)
     {
@@ -733,8 +733,8 @@ void drawBitmaps3c400x300()
       do
       {
         display.fillScreen(GxEPD_WHITE);
-        display.drawInvertedBitmap(0, 0, bitmap_pairs[i].black, display.width(), display.height(), GxEPD_BLACK);
-        display.drawInvertedBitmap(0, 0, bitmap_pairs[i].red, display.width(), display.height(), GxEPD_RED);
+        display.drawInvertedBitmap((display.width()-400)/2, (display.height()-300)/2, bitmap_pairs[i].black, 400, 300, GxEPD_BLACK);
+        display.drawInvertedBitmap((display.width()-400)/2, (display.height()-300)/2, bitmap_pairs[i].red, 400, 300, GxEPD_RED);
       }
       while (display.nextPage());
       delay(2000);


### PR DESCRIPTION
Since there are no example 3-color 640x384 bitmaps, I have modified the example so that 1-color 640x384 bitmaps and 3-color 400x300 bitmaps are drawn if the GDEW075Z09 display is selected.
For the 400x300 bitmaps, I have modified the method (which originally worked only if the display had the exact same size as the bitmaps) so that it works as expected also on bigger displays, such as the GDEW075Z09. In that case they are centered.

Only tested on WaveShare 7.5-inch bwr display (and ESP8266).